### PR TITLE
🐛 Add default url in case no url is found

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -5,6 +5,7 @@ declare type CLIFlags = Partial<{
 }>;
 
 declare interface PackageJSON {
+  name: string;
   version: string;
   license?: string;
   repository?: {

--- a/src/licenseUtils.ts
+++ b/src/licenseUtils.ts
@@ -6,7 +6,7 @@ const validLicense = [
   'GPL',
   'Apache-2.0',
   'BSD-3-Clause',
-  "ISC"
+  'ISC',
 ];
 
 export const licenseSnippets = [
@@ -14,6 +14,10 @@ export const licenseSnippets = [
   'The GNU General Public License is a free, copyleft license for software and other kinds of works.',
 ];
 
-export function isValidLicense(license: string) {
-  return validLicense.some(i => i === license);
+export function isValidLicense(license?: string) {
+  if (!license) {
+    return false;
+  }
+
+  return validLicense.some((i) => i === license);
 }

--- a/src/licenseUtils.ts
+++ b/src/licenseUtils.ts
@@ -14,10 +14,5 @@ export const licenseSnippets = [
   'The GNU General Public License is a free, copyleft license for software and other kinds of works.',
 ];
 
-export function isValidLicense(license?: string) {
-  if (!license) {
-    return false;
-  }
-
-  return validLicense.some((i) => i === license);
-}
+export const isValidLicense = (license?: string) =>
+  validLicense.some((i) => i === license);

--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -64,6 +64,6 @@ export function getPackageInfo(pkg: PackageJSON): {
   return {
     version: pkg.version,
     license: pkg.license,
-    url,
+    url: url ?? `https://npmjs.com/package/${pkg.name}`,
   };
 }

--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -50,7 +50,7 @@ export async function getPackageDescriptor(dep: string) {
 export function getPackageInfo(pkg: PackageJSON): {
   version: PackageJSON['version'];
   license: PackageJSON['license'];
-  url: undefined | string;
+  url: string;
 } {
   const [url] = [
     pkg.homepage,
@@ -59,7 +59,7 @@ export function getPackageInfo(pkg: PackageJSON): {
     pkg.repo,
   ]
     .filter(Boolean)
-    .filter((url) => url.startsWith('https'));
+    .filter((url) => url?.startsWith('https'));
 
   return {
     version: pkg.version,

--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -47,11 +47,7 @@ export async function getPackageDescriptor(dep: string) {
 /**
  * Returns metadata for package.json content
  */
-export function getPackageInfo(pkg: PackageJSON): {
-  version: PackageJSON['version'];
-  license: PackageJSON['license'];
-  url: string;
-} {
+export function getPackageInfo(pkg: PackageJSON) {
   const [url] = [
     pkg.homepage,
     pkg.repository?.url,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,8 @@
       "*": ["node_modules/*"]
     },
     "target": "es6",
-    "declaration": true
+    "declaration": true,
+    "strict": true
   },
-  "include": [
-    "src",
-    "global.d.ts"
-  ]
+  "include": ["src", "global.d.ts"]
 }


### PR DESCRIPTION
In the current implementation if no valid `https` link is found for a package, the `url` key won't be present in the json output for this package.

Instead of omitting the `url` key, this PR will use a default npm url instead. This way, when you need info on a package when you're looking at the licenses json file, it's easier to get a lead to more information of a package.