### PR TITLE
refactor: remove misleading default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ node node_modules/.bin/npm-license-scraper
 ### Options
 
 - `--export [filename]`: Export to a JSON file. (default `./licenses.json`)
-- `--includeDev`: Include dev dependencies in output (default `true`)
+- `--includeDev`: Include dev dependencies in output (default `false`)
 - `--exclude [package|package,package,package]`: Ignore certain packages from the check (e.g submodules, monorepo or private packages)
 
 ## Output format

--- a/dist/packageUtils.js
+++ b/dist/packageUtils.js
@@ -23,7 +23,7 @@ function hasProp(o, prop) {
  */
 
 
-async function getDependencies(includeDev = true) {
+async function getDependencies(includeDev) {
   try {
     const pkg = await (0, _util.readJSONFile)(_path.default.join(process.cwd(), 'package.json'));
 

--- a/src/packageUtils.ts
+++ b/src/packageUtils.ts
@@ -12,7 +12,7 @@ function hasProp(o: Record<string, any>, prop: string) {
  * If false is passed, will return a tuple with only the dependencies
  */
 export async function getDependencies(
-  includeDev = true
+  includeDev: boolean,
 ): Promise<[string[], string[] | null]> {
   try {
     const pkg = await readJSONFile(path.join(process.cwd(), 'package.json'));


### PR DESCRIPTION
We call it like this 
```ts
getDependencies(Boolean(flags.includeDev))
```
so the default is never used.